### PR TITLE
Feat: telemetry ingestion service and in-memory state store

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -32,20 +32,168 @@ Orbverflow/
 
 ```
 
-📁 Issues-1
+## [✅] Issue-2: Implemented telemetry ingestion service and state store.
 
-✅ (已完成) Commit 1 — skeleton + healthcheck
-- 建 backend/ + FastAPI app
-- GET /healthz 回 {ok:true}
+Features:
+- In-memory time-window telemetry store (10 minutes per satellite).
+- HTTP ingestion endpoint: POST /ingest/telemetry
+- Query APIs:
+  - GET /state/latest
+  - GET /state/sat/{sat_id}?minutes=N
+- Simulator batches are persisted automatically.
+- Scenario injection (JAMMING) affects stored & queried telemetry and auto-reverts to NORMAL.
 
-Commit 2 — simulator engine（先不用 WS）
+Verified via curl:
+- /state/latest returns 5 satellites.
+- /state/sat/SatB returns recent telemetry records.
+- JAMMING scenario shows snr drop + packet loss spike, then recovers.
 
-- 每秒生成 5 筆 telemetry（print log 或暫存 list）
-- 支援 scenario state machine
+Example output
+```
+curl http://127.0.0.1:8000/state/latest | jq .
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  2257  100  2257    0     0  1102k      0 --:--:-- --:--:-- --:--:-- 2204k
+{
+  "ok": true,
+  "count": 5,
+  "latest": {
+    "SatA": {
+      "timestamp": 1769412641.4754493,
+      "sat_id": "SatA",
+      "lat": 32.48000000000123,
+      "lon": 165.90000000000822,
+      "alt": 550,
+      "snr_db": 17.297346551459356,
+      "rssi_dbm": -70,
+      "packet_loss_pct": 0.8630174434738136,
+      "modem_reset_count": 0,
+      "power_watt": null,
+      "link_state": "OK",
+      "spoofing": false,
+      "provenance": {
+        "source_vendor": "SIM",
+        "source_dataset_id": "SIM_DEMO_2026_01",
+        "source_file": "simulator",
+        "source_fields": [
+          "snr_db",
+          "packet_loss_pct",
+          "lat",
+          "lon",
+          "link_state"
+        ]
+      }
+    },
+    "SatB": {
+      "timestamp": 1769412641.475535,
+      "sat_id": "SatB",
+      "lat": 32.68000000000116,
+      "lon": 166.2000000000083,
+      "alt": 550,
+      "snr_db": 15.717999587043952,
+      "rssi_dbm": -70,
+      "packet_loss_pct": 2.905781022661099,
+      "modem_reset_count": 0,
+      "power_watt": null,
+      "link_state": "OK",
+      "spoofing": false,
+      "provenance": {
+        "source_vendor": "SIM",
+        "source_dataset_id": "SIM_DEMO_2026_01",
+        "source_file": "simulator",
+        "source_fields": [
+          "snr_db",
+          "packet_loss_pct",
+          "lat",
+          "lon",
+          "link_state"
+        ]
+      }
+    },
+    "SatC": {
+      "timestamp": 1769412641.4755414,
+      "sat_id": "SatC",
+      "lat": 32.88000000000109,
+      "lon": 166.50000000000838,
+      "alt": 550,
+      "snr_db": 14.165625677390967,
+      "rssi_dbm": -70,
+      "packet_loss_pct": 2.825360911325789,
+      "modem_reset_count": 0,
+      "power_watt": null,
+      "link_state": "OK",
+      "spoofing": false,
+      "provenance": {
+        "source_vendor": "SIM",
+        "source_dataset_id": "SIM_DEMO_2026_01",
+        "source_file": "simulator",
+        "source_fields": [
+          "snr_db",
+          "packet_loss_pct",
+          "lat",
+          "lon",
+          "link_state"
+        ]
+      }
+    },
+    "SatD": {
+      "timestamp": 1769412641.475547,
+      "sat_id": "SatD",
+      "lat": 33.08000000000102,
+      "lon": 166.80000000000848,
+      "alt": 550,
+      "snr_db": 12.313867318534276,
+      "rssi_dbm": -70,
+      "packet_loss_pct": 2.653880167559865,
+      "modem_reset_count": 0,
+      "power_watt": null,
+      "link_state": "OK",
+      "spoofing": false,
+      "provenance": {
+        "source_vendor": "SIM",
+        "source_dataset_id": "SIM_DEMO_2026_01",
+        "source_file": "simulator",
+        "source_fields": [
+          "snr_db",
+          "packet_loss_pct",
+          "lat",
+          "lon",
+          "link_state"
+        ]
+      }
+    },
+    "SatE": {
+      "timestamp": 1769412641.4755518,
+      "sat_id": "SatE",
+      "lat": 33.280000000000946,
+      "lon": 167.10000000000855,
+      "alt": 550,
+      "snr_db": 14.987816033499346,
+      "rssi_dbm": -70,
+      "packet_loss_pct": 1.1485748905837014,
+      "modem_reset_count": 0,
+      "power_watt": null,
+      "link_state": "OK",
+      "spoofing": false,
+      "provenance": {
+        "source_vendor": "SIM",
+        "source_dataset_id": "SIM_DEMO_2026_01",
+        "source_file": "simulator",
+        "source_fields": [
+          "snr_db",
+          "packet_loss_pct",
+          "lat",
+          "lon",
+          "link_state"
+        ]
+      }
+    }
+  }
+}
+```
 
-Commit 3 — WebSocket + scenario trigger
-
-- WS client 連上後，每秒收到 batch
-- POST /scenario/trigger 可切換情境（含 duration 自動回 normal）
-
-做到這裡，Issue-1 就可以關。
+```
+"http://127.0.0.1:8000/state/sat/SatB?minutes=5"
+{"ok":true,"sat_id":"SatB","minutes":5,"count":300,"records":[{"timestamp":1769412518.4056258,"sat_id":"SatB","lat":31.45000000000121,"lon":160.0500000000069,"alt":550.0,"snr_db":13.926087901892256,"rssi_dbm":-70.0,"packet_loss_pct":1.010697695965745,"modem_reset_count":0,"power_watt":null,"link_state":"OK","spoofing":false,"provenance":{"source_vendor":"SIM","source_dataset_id":"SIM_DEMO_2026_01","source_file":"simulator","source_fields":["snr_db","packet_loss_pct","lat","lon","link_state"]}},{"timestamp":1769412519.4065118,"sat_id":"SatB","lat":31.460000000001212,"lon":160.1000000000069,"alt":550.0,"snr_db":16.751649325504154,"rssi_dbm":-70.0,"packet_loss_pct":2.1469290706401525,"modem_reset_count":0,"power_watt":null,"link_state":"OK","spoofing":false,"provenance":{"source_vendor":"SIM","source_dataset_id":"SIM_DEMO_2026_01","source_file":"simulator","source_fields":["snr_db","packet_loss_pct","lat","lon","link_state"]}},{"timestamp":1769412520.4070203,"sat_id":"SatB","lat":31.470000000001214,"lon":160.1500000000069,"alt":550.0,"snr_db":17.452949087315822,"rssi_dbm":-70.0,"packet_loss_pct":0.8426308970622415,"modem_reset_count":0,"power_watt":null,"link_state":"OK","spoofing":false,"provenance":{"source_vendor":"SIM","source_dataset_id":"SIM_DEMO_2026_01","source_file":"simulator","source_fields":["snr_db","packet_loss_pct","lat","lon","link_state"]}},{"timestamp":1769412521.407445,"sat_id":"SatB","lat":31.48000000000121 ......
+}}
+```

--- a/backend/src/orbverflow/app_state.py
+++ b/backend/src/orbverflow/app_state.py
@@ -1,6 +1,9 @@
 from orbverflow.ws import WebSocketHub
 from orbverflow.simulator.engine import SimulatorEngine
+from orbverflow.state_store import TelemetryStateStore
 
-# singletons (demo 用很 OK)
 hub = WebSocketHub()
 engine = SimulatorEngine()
+
+# issue-2 store
+store = TelemetryStateStore(window_seconds=600)  # 10 min

--- a/backend/src/orbverflow/main.py
+++ b/backend/src/orbverflow/main.py
@@ -1,17 +1,22 @@
 import asyncio
 from fastapi import FastAPI
 
-from orbverflow.app_state import hub, engine
+from orbverflow.app_state import hub, engine, store
 from orbverflow.models import TelemetryBatch
 from orbverflow.routes.health import router as health_router
 from orbverflow.routes.telemetry import router as telemetry_router
 from orbverflow.routes.scenario import router as scenario_router
+from orbverflow.routes.ingest import router as ingest_router
+from orbverflow.routes.state import router as state_router
+from orbverflow.app_state import store as app_store
 
 app = FastAPI(title="Orbverflow Backend")
 
 app.include_router(health_router)
 app.include_router(telemetry_router)
 app.include_router(scenario_router)
+app.include_router(ingest_router)
+app.include_router(state_router)
 
 
 async def simulator_loop():
@@ -19,6 +24,9 @@ async def simulator_loop():
     while True:
         tick += 1
         records = engine.generate_batch()
+
+        # For issue-2: store it
+        await store.add_records(records)
 
         payload = TelemetryBatch(
             scenario=engine.current_scenario,
@@ -28,6 +36,7 @@ async def simulator_loop():
 
         await hub.broadcast_json(payload)
         await asyncio.sleep(1)
+
 
 
 @app.on_event("startup")

--- a/backend/src/orbverflow/routes/ingest.py
+++ b/backend/src/orbverflow/routes/ingest.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
+from typing import List, Union
+
+from orbverflow.models import TelemetryRecord, TelemetryBatch
+from orbverflow.app_state import store
+
+router = APIRouter(prefix="/ingest", tags=["ingest"])
+
+
+class IngestResponse(BaseModel):
+    ok: bool = True
+    ingested: int
+
+
+@router.post("/telemetry", response_model=IngestResponse)
+async def ingest_telemetry(payload: Union[TelemetryBatch, List[TelemetryRecord]]):
+    # allow either batch or list of records
+    if isinstance(payload, TelemetryBatch):
+        records = payload.records
+    else:
+        records = payload
+
+    await store.add_records(records)
+    return IngestResponse(ingested=len(records))
+
+
+@router.websocket("/ws/ingest")
+async def ws_ingest(ws: WebSocket):
+    await ws.accept()
+    try:
+        while True:
+            msg = await ws.receive_json()
+            # expect TelemetryBatch shape (recommended)
+            batch = TelemetryBatch(**msg)
+            await store.add_records(batch.records)
+            await ws.send_json({"ok": True, "ingested": len(batch.records)})
+    except WebSocketDisconnect:
+        return

--- a/backend/src/orbverflow/routes/state.py
+++ b/backend/src/orbverflow/routes/state.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Query
+from orbverflow.app_state import store
+
+router = APIRouter(prefix="/state", tags=["state"])
+
+
+@router.get("/latest")
+async def get_latest_all():
+    print(f"[state/latest] store id = {id(store)}")
+    latest = await store.latest_all()
+    return {
+        "ok": True,
+        "count": len(latest),
+        "latest": {k: v.model_dump() for k, v in latest.items()},
+    }
+
+
+@router.get("/sat/{sat_id}")
+async def get_recent_sat(sat_id: str, minutes: int = Query(5, ge=1, le=60)):
+    records = await store.recent_sat(sat_id, minutes=minutes)
+    return {
+        "ok": True,
+        "sat_id": sat_id,
+        "minutes": minutes,
+        "count": len(records),
+        "records": [r.model_dump() for r in records],
+    }
+    

--- a/backend/src/orbverflow/simulator/engine.py
+++ b/backend/src/orbverflow/simulator/engine.py
@@ -84,7 +84,7 @@ class SimulatorEngine:
             self._apply_scenario(sat)
 
             record = TelemetryRecord(
-                timestamp=datetime.utcnow().timestamp(), 
+                timestamp=time.time(), 
                 sat_id=sat.sat_id,
                 lat=sat.lat,
                 lon=sat.lon,

--- a/backend/src/orbverflow/state_store.py
+++ b/backend/src/orbverflow/state_store.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import time
+import asyncio
+from collections import deque
+from typing import Deque, Dict, List, Optional
+
+from orbverflow.models import TelemetryRecord
+
+
+class TelemetryStateStore:
+    """
+    In-memory time-window store:
+    state_store = { "SatA": deque([TelemetryRecord...]), ... }
+    Keep last window_seconds per sat.
+    """
+
+    def __init__(self, window_seconds: int = 600) -> None:
+        self.window_seconds = window_seconds
+        self._store: Dict[str, Deque[TelemetryRecord]] = {}
+        self._lock = asyncio.Lock()
+
+    async def add_records(self, records: List[TelemetryRecord]) -> None:
+        now = time.time()
+        cutoff = now - self.window_seconds
+        async with self._lock:
+            for r in records:
+                dq = self._store.setdefault(r.sat_id, deque())
+                dq.append(r)
+                # prune
+                while dq and dq[0].timestamp < cutoff:
+                    dq.popleft()
+    
+
+    async def latest_all(self) -> Dict[str, TelemetryRecord]:
+        async with self._lock:
+            out: Dict[str, TelemetryRecord] = {}
+            for sat_id, dq in self._store.items():
+                if dq:
+                    out[sat_id] = dq[-1]
+            return out
+
+    async def recent_sat(self, sat_id: str, minutes: int = 5) -> List[TelemetryRecord]:
+        now = time.time()
+        cutoff = now - minutes * 60
+        async with self._lock:
+            dq = self._store.get(sat_id)
+            if not dq:
+                return []
+            return [r for r in dq if r.timestamp >= cutoff]


### PR DESCRIPTION
This PR implements Issue-2: telemetry ingestion and state storage.

### Features
- HTTP ingestion endpoint: `POST /ingest/telemetry`
- In-memory time window store (10 minutes per satellite)
- Query APIs:
  - `GET /state/latest`
  - `GET /state/sat/{sat_id}?minutes=N`
- Simulator auto-persist integration
- Scenario effects reflected in stored telemetry

### Verified
- Realtime simulator data stored correctly
- JAMMING scenario impacts telemetry and recovers
- Queries return correct latest and historical data

[Closes Issue#2](https://github.com/leozzmc/Orbverflow/issues/2)
